### PR TITLE
Fix license link path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ You can now choose how Segment identifies users via the new `segment_io_user_id_
 | `email`            | Uses user email as the `userId`                                     |
 | `sso_external_id`  | Uses the user’s external ID from SSO if present                     |
 | `use_anon`         | Uses a custom, deterministic, 36-character `anonymousId`            |
-| `discourse_id'     | Uses the internal Discourse user ID (e.g. `123`)                    |
+| `discourse_id`     | Uses the internal Discourse user ID (e.g. `123`)                    |
 
-The `anonymousId` format is:  
+The `anonymousId` format is:
 ```
 <discourse_id>-dc-<derived_string>
 ```
@@ -44,13 +44,13 @@ User.pluck(:id).each do |uid|
 end
 ```
 
-**Note:**  
+**Note:**
 If your site previously used `discourse_id`, and you are switching to `use_anon`, Segment will treat these as **new distinct profiles** unless you use Unify rules to merge.
 
 
 ### Installation
 
-Watch Tutorial Video: https://youtu.be/AKR3ki9Kj38  
+Watch Tutorial Video: https://youtu.be/AKR3ki9Kj38
 In Segment, create a `Ruby` source and use your write key to configure this plugin in Discourse.
 
 ### Contributing
@@ -59,4 +59,4 @@ Please see [CONTRIBUTING.md](/CONTRIBUTING.md).
 
 ### License
 
-This plugin is © 2016 Kyle Welsby. It is free software, licensed under the terms specified in the [LICENSE](./license) file. 
+This plugin is © 2016 Kyle Welsby. It is free software, licensed under the terms specified in the [LICENSE](/LICENSE) file.

--- a/plugin.rb
+++ b/plugin.rb
@@ -25,14 +25,14 @@ after_initialize do
 
       prefix = "#{user.id}-dc-" # fixed prefix with user.id
       input = "discourse_custom_anon_v1:#{user.id}:#{Rails.application.secret_key_base}" # salt input with app secret
-      
+
       # OpenSSL::Digest is preloaded in Discourse/Rails environments, no extra 'require' needed
       full_hash = OpenSSL::Digest::SHA256.hexdigest(input) # hashed string stays stable per user
 
       remaining_len = 36 - prefix.length
       # Trim hash so final ID = 36 chars
       hash_segment = remaining_len > 0 ? full_hash[0...remaining_len] : ""
-      
+
       "#{prefix}#{hash_segment}"
     end
 


### PR DESCRIPTION
## Summary
- link to license file using absolute `/LICENSE` path

## Testing
- `ruby -c plugin.rb`


------
https://chatgpt.com/codex/tasks/task_b_683cee7391f0832ba73952641d6c3aad